### PR TITLE
Support additional kernel start command arguments

### DIFF
--- a/kernda/cli.py
+++ b/kernda/cli.py
@@ -8,7 +8,7 @@ import sys
 from os.path import join as pjoin, dirname, isfile, expanduser
 
 # Final form of our activation command!
-FULL_CMD_TMPL = 'source "{env_dir}/bin/activate" "{env_dir}" && exec {start_cmd}'
+FULL_CMD_TMPL = 'source "{env_dir}/bin/activate" "{env_dir}" && exec {start_cmd} {start_args}'
 
 
 def add_activation(args):
@@ -49,13 +49,14 @@ def add_activation(args):
 
     if not isfile(pjoin(bin_dir, 'activate')):
         print(spec)
-        print('Error: {} does not contain a conda activate script'.format(bin_dir), 
+        print('Error: {} does not contain a conda activate script'.format(bin_dir),
               file=sys.stderr)
         return 1
 
     env_dir = dirname(bin_dir)
     start_cmd = ' '.join(spec['argv'])
-    full_cmd = FULL_CMD_TMPL.format(env_dir=env_dir, start_cmd=start_cmd)
+    full_cmd = FULL_CMD_TMPL.format(env_dir=env_dir, start_cmd=start_cmd,
+                                    start_args=args.start_args)
     spec['argv'] = ['bash', '-c', full_cmd]
 
     if args.display_name:
@@ -90,6 +91,10 @@ def cli(argv=sys.argv[1:]):
                         help="Path to the conda environment that should \
                         activate (default: prefix path to the \
                         kernel in the existing kernel spec file)")
+    parser.add_argument("--start-args", dest="start_args", type=str,
+                        default='',
+                        help="Additional arguments to append to the kernel \
+                        start command (default: none)")
     args, unknown = parser.parse_known_args(argv)
     return add_activation(args)
 

--- a/kernda/cli.py
+++ b/kernda/cli.py
@@ -7,7 +7,8 @@ import os
 import sys
 from os.path import join as pjoin, dirname, isfile, expanduser
 
-# Final form of our activation command!
+# This is the final form the kernel start command will take
+# after running kernda. It's at the module-level for ease of reference only.
 FULL_CMD_TMPL = 'source "{env_dir}/bin/activate" "{env_dir}" && exec {start_cmd} {start_args}'
 
 
@@ -80,21 +81,21 @@ def cli(argv=sys.argv[1:]):
     parser.add_argument('kernelspec', metavar='kernel.json',
                         help='Path to a kernel spec')
     parser.add_argument('--display-name', dest='display_name', type=str,
-                        help='New display name for the kernel (default: keep \
-                        the original)')
+                        help='New display name for the kernel (default: keep '
+                        'the original)')
     parser.add_argument('--overwrite', '-o', dest='overwrite',
                         action='store_const',
                         const=True, default=False,
-                        help='Overwrite the existing kernel spec (default: \
-                        False, print to stdout')
+                        help='Overwrite the existing kernel spec (default: '
+                        'False, print to stdout')
     parser.add_argument("--env-dir", action="store", default=None,
-                        help="Path to the conda environment that should \
-                        activate (default: prefix path to the \
-                        kernel in the existing kernel spec file)")
+                        help="Path to the conda environment that should "
+                        "activate (default: prefix path to the "
+                        "kernel in the existing kernel spec file)")
     parser.add_argument("--start-args", dest="start_args", type=str,
                         default='',
-                        help="Additional arguments to append to the kernel \
-                        start command (default: none)")
+                        help="Additional arguments to append to the kernel "
+                        "start command (default: '')")
     args, unknown = parser.parse_known_args(argv)
     return add_activation(args)
 

--- a/test/test_cli.py
+++ b/test/test_cli.py
@@ -68,3 +68,10 @@ def test_overwritten_spec(kernel):
     rv = cli(['-o', kernel.spec])
     assert rv == 0
     assert kernel.env in kernel_conda(kernel)
+
+
+def test_start_args(kernel):
+    """The kernel spec should include additional arguments."""
+    rv = cli(['-o', kernel.spec, '--start-args=--Completer.use_jedi=False'])
+    assert rv == 0
+    assert kernel.env in kernel_conda(kernel)


### PR DESCRIPTION
e.g., `--start-args="--Completer.use_jedi=False"` to add a
command line option to the kernel's start command that disables
jedi for that kernel