### PR TITLE
Escape the additional arguments as necessary

### DIFF
--- a/kernda/cli.py
+++ b/kernda/cli.py
@@ -6,7 +6,10 @@ import json
 import os
 import sys
 from os.path import join as pjoin, dirname, isfile, expanduser
-from pipes import quote
+try:
+    from shlex import quote
+except ImportError:
+    from pipes import quote
 
 
 # This is the final form the kernel start command will take

--- a/kernda/cli.py
+++ b/kernda/cli.py
@@ -60,12 +60,12 @@ def add_activation(args):
         return 1
 
     env_dir = dirname(bin_dir)
-    start_cmd = ' '.join(spec['argv'])
+    start_cmd = ' '.join(quote(x) for x in spec['argv'])
     full_cmd = FULL_CMD_TMPL.format(
         env_dir=env_dir,
         start_cmd=start_cmd,
         start_args=args.start_args)
-    spec['argv'] = ['bash', '-c', quote(full_cmd)]
+    spec['argv'] = ['bash', '-c', full_cmd]
 
     if args.display_name:
         spec['display_name'] = args.display_name

--- a/kernda/cli.py
+++ b/kernda/cli.py
@@ -6,6 +6,8 @@ import json
 import os
 import sys
 from os.path import join as pjoin, dirname, isfile, expanduser
+from pipes import quote
+
 
 # This is the final form the kernel start command will take
 # after running kernda. It's at the module-level for ease of reference only.
@@ -56,9 +58,11 @@ def add_activation(args):
 
     env_dir = dirname(bin_dir)
     start_cmd = ' '.join(spec['argv'])
-    full_cmd = FULL_CMD_TMPL.format(env_dir=env_dir, start_cmd=start_cmd,
-                                    start_args=args.start_args)
-    spec['argv'] = ['bash', '-c', full_cmd]
+    full_cmd = FULL_CMD_TMPL.format(
+        env_dir=env_dir,
+        start_cmd=start_cmd,
+        start_args=args.start_args)
+    spec['argv'] = ['bash', '-c', quote(full_cmd)]
 
     if args.display_name:
         spec['display_name'] = args.display_name


### PR DESCRIPTION
For some command line arguments (such as those produced by IRkernel we
need some additional escaping due to its use of parens